### PR TITLE
Fix error "Package 'libpng12-dev' has no installation candidate"

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
-        libpng12-dev \
+        libpng-dev \
         ssmtp \
         gettext \
         screen && \


### PR DESCRIPTION
#2 